### PR TITLE
Changes to run emulator on Windows command line

### DIFF
--- a/emulators/python/g15d/EmulAscii.py
+++ b/emulators/python/g15d/EmulAscii.py
@@ -7,42 +7,60 @@
 # returns None if no chars present
 #
 
-import select
-import sys
-import termios
-import tty
 import os
 
-
-class EmulAscii():
-    def __init__(self, emul):
-        self.emul = emul
-        self.open()
-
-    def open(self):
-        self.fd = sys.stdin.fileno()
-        self.old_settings = termios.tcgetattr(self.fd)
-#        tty.setraw(sys.stdin.fileno())
-        tty.setcbreak(sys.stdin.fileno())
-
-    def close(self):
-        # restore original terminal settings
-        print("Restoring terminal settings")
-        termios.tcsetattr(self.fd, termios.TCSADRAIN, self.old_settings)
-
-        # above statement does not seem work on MAC
-        os.system("stty sane")
-
-    def kbhit(self):
-        rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
-        if rlist:
-            c = sys.stdin.read(1)
-
-            if c == 3:      # control-c
-                self.emul.quit()
-
-            print(c, end='')
-            return c
-        else:
+if os.name == 'nt':
+    #Windows Version
+    import msvcrt
+    class EmulAscii():
+        def __init__(self, emul):
+            self.emul = emul
+            self.open()
+        def open(self):
+            return
+        def close(self):
+            return
+        def kbhit(self):
+            if msvcrt.kbhit():
+                return msvcrt.getch().decode('ASCII')
             return False
+            
+else:
+    #Linux Version
+    import select
+    import sys
+    import termios
+    import tty
+
+    class EmulAscii():
+        def __init__(self, emul):
+            self.emul = emul
+            self.open()
+
+        def open(self):
+            self.fd = sys.stdin.fileno()
+            self.old_settings = termios.tcgetattr(self.fd)
+    #        tty.setraw(sys.stdin.fileno())
+            tty.setcbreak(sys.stdin.fileno())
+
+        def close(self):
+            # restore original terminal settings
+            print("Restoring terminal settings")
+            termios.tcsetattr(self.fd, termios.TCSADRAIN, self.old_settings)
+
+            # above statement does not seem work on MAC
+            os.system("stty sane")
+
+        def kbhit(self):
+            rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
+            if rlist:
+                c = sys.stdin.read(1)
+
+                if c == 3:      # control-c
+                    self.emul.quit()
+
+                print(c, end='')
+                return c
+            else:
+                return False
 

--- a/emulators/python/g15d/EmulGetc.py
+++ b/emulators/python/g15d/EmulGetc.py
@@ -64,7 +64,7 @@ class CharIO:
             sys.stdout.write(k)
             sys.stdout.flush()
 
-            if k == '\n':
+            if k == '\n' or k == '\r':
                 line = self.buffer
                 self.buffer = ""
                 print("placing onto cmd queue: %s" % line)


### PR DESCRIPTION
EmulAscii.py chooses between a Windows and Linux implementation of the EmulAscii class.

EmulGetc recognizes \n or \r as the end of a command

This is NOT tested on linux sorry

Here is a screenshot of an interactive session on windows:
![image](https://github.com/user-attachments/assets/37b0b8cf-4a4a-4fb1-8772-c20c6b0f67fb)
